### PR TITLE
#261 cpz3177

### DIFF
--- a/neclib/devices/bias_reader/__init__.py
+++ b/neclib/devices/bias_reader/__init__.py
@@ -1,0 +1,1 @@
+from .cpz3177 import CPZ3177  # noqa: F401

--- a/neclib/devices/bias_reader/bias_reader_base.py
+++ b/neclib/devices/bias_reader/bias_reader_base.py
@@ -12,4 +12,4 @@ class BiasReader(DeviceBase):
 
     @abstractmethod
     def get_data(self) -> u.Quantity:
-        ...  # Not yet. None should be changed u.Quantity?
+        ...

--- a/neclib/devices/bias_reader/bias_reader_base.py
+++ b/neclib/devices/bias_reader/bias_reader_base.py
@@ -1,0 +1,15 @@
+from abc import abstractmethod
+
+import astropy.units as u
+
+from ..device_base import DeviceBase
+
+
+class BiasReader(DeviceBase):
+
+    Manufacturer: str = ""
+    Model: str
+
+    @abstractmethod
+    def get_data(self) -> u.Quantity:
+        ...  # Not yet. None should be changed u.Quantity?

--- a/neclib/devices/bias_reader/bias_reader_base.py
+++ b/neclib/devices/bias_reader/bias_reader_base.py
@@ -17,3 +17,7 @@ class BiasReader(DeviceBase):
     @abstractmethod
     def get_bias_current(self, ch) -> u.Quantity:
         ...
+
+    @abstractmethod
+    def finalize(self) -> None:
+        ...

--- a/neclib/devices/bias_reader/bias_reader_base.py
+++ b/neclib/devices/bias_reader/bias_reader_base.py
@@ -11,5 +11,9 @@ class BiasReader(DeviceBase):
     Model: str
 
     @abstractmethod
-    def get_data(self) -> u.Quantity:
+    def get_voltage(self, ch) -> u.Quantity:
+        ...
+
+    @abstractmethod
+    def get_current(self, ch) -> u.Quantity:
         ...

--- a/neclib/devices/bias_reader/bias_reader_base.py
+++ b/neclib/devices/bias_reader/bias_reader_base.py
@@ -11,9 +11,9 @@ class BiasReader(DeviceBase):
     Model: str
 
     @abstractmethod
-    def get_voltage(self, ch) -> u.Quantity:
+    def get_bias_voltage(self, ch) -> u.Quantity:
         ...
 
     @abstractmethod
-    def get_current(self, ch) -> u.Quantity:
+    def get_bias_current(self, ch) -> u.Quantity:
         ...

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -49,7 +49,7 @@ class CPZ3177(BiasReader):
             for data in data_li_2:
                 d = sum(data) / self.ave_num
                 ave_data_li.append(d)
-            return ave_data_li[ch]
+            return ave_data_li[ch - 1]
 
     def get_bias_voltage(self, ch) -> u.Quantity:
         pci_ch = 2 * ch - 1

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -50,9 +50,17 @@ class CPZ3177(BiasReader):
                 d = sum(data) / self.ave_num
                 ave_data_li.append(d)
             return ave_data_li[ch]
-        # get_dataを参照させて次の二つを出力する。ただし各chのうち二つずつが1組でバイアスボックス上のchになっているのでget_volとget_currの引数はボックスのchに合わせること。
-        def get_voltage(self, ch) -> u.Quantity:  # odd number ch is voltage (x10)
-            ...
 
-        def get_current(self, ch) -> u.Quantity:  # even number ch is current (x1000)
-            ...
+    def get_bias_voltage(self, ch) -> u.Quantity:  # odd number pci_ch is voltage (x10).
+        pci_ch = 2 * ch - 1
+        return self.get_data(pci_ch) * 10 * u.mV
+
+    # This "ch" which is argument of this function is ch of bias box, not pci board.
+
+    def get_bias_current(
+        self, ch
+    ) -> u.Quantity:  # even number pci_ch is current (x1000).
+        pci_ch = 2 * ch
+        return self.get_data(pci_ch) * 1000 * u.microampere
+
+    # This "ch" which is argument of this function is ch of bias box, not pci board.

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -1,7 +1,6 @@
 import pyinterface
 import astropy.units as u
 
-from ... import config
 from ...devices import utils
 
 from .bias_reader_base import BiasReader
@@ -11,21 +10,24 @@ class CPZ3177(BiasReader):
     Manufacturer = "Interface"
     Model = "CPZ3177"
 
-    Identifier = config.rx_cpz3177_rsw_id
+    Identifier = "rsw_id"
 
     def __init__(self) -> None:
 
-        self.ave_num = rospy.get_param("~ave_num")
-        self.smpl_freq = rospy.get_param("~smpl_freq")
+        self.rsw_id = self.Config.rsw_id
+        self.ave_num = self.Config.ave_num
+        self.smpl_freq = self.Config.smpl_freq
+        self.single_diff = self.Config.single_diff
+        self.all_ch_num = self.Config.all_ch_num
 
-        self.ad = pyinterface.open(3177, config.rx_cpz3177_rsw_id)
+        self.ad = pyinterface.open(3177, self.rsw_id)
         self.ad.stop_sampling()
         self.ad.initialize()
         self.ad.set_sampling_config(
-            smpl_ch_req=smpl_ch_req,
+            smpl_ch_req=smpl_ch_req,  # imcomplete. Add list?
             smpl_num=1000,
             smpl_freq=self.smpl_freq,
-            single_diff=single_diff,
+            single_diff=self.single_diff,
             trig_mode="ETERNITY",
         )
         self.ad.start_sampling("ASYNC")
@@ -35,7 +37,7 @@ class CPZ3177(BiasReader):
             offset = self.ad.get_status()["smpl_count"] - self.ave_num
             data = self.ad.read_sampling_buffer(self.ave_num, offset)
             data_li_2 = []
-            for i in range(all_ch_num):
+            for i in range(self.all_ch_num):
                 data_li = []
                 for k in range(self.ave_num):
                     data_li.append(data[k][i])

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -1,0 +1,48 @@
+import pyinterface
+import astropy.units as u
+
+from ... import config
+from ...devices import utils
+
+from .bias_reader_base import BiasReader
+
+
+class CPZ3177(BiasReader):
+    Manufacturer = "Interface"
+    Model = "CPZ3177"
+
+    Identifier = config.rx_cpz3177_rsw_id
+
+    def __init__(self) -> None:
+
+        self.ave_num = rospy.get_param("~ave_num")
+        self.smpl_freq = rospy.get_param("~smpl_freq")
+
+        self.ad = pyinterface.open(3177, config.rx_cpz3177_rsw_id)
+        self.ad.stop_sampling()
+        self.ad.initialize()
+        self.ad.set_sampling_config(
+            smpl_ch_req=smpl_ch_req,
+            smpl_num=1000,
+            smpl_freq=self.smpl_freq,
+            single_diff=single_diff,
+            trig_mode="ETERNITY",
+        )
+        self.ad.start_sampling("ASYNC")
+
+    def get_data(self) -> u.Quantity:
+        with utils.busy(self, "busy"):
+            offset = self.ad.get_status()["smpl_count"] - self.ave_num
+            data = self.ad.read_sampling_buffer(self.ave_num, offset)
+            data_li_2 = []
+            for i in range(all_ch_num):
+                data_li = []
+                for k in range(self.ave_num):
+                    data_li.append(data[k][i])
+                data_li_2.append(data_li)
+
+            ave_data_li = []
+            for data in data_li_2:
+                d = sum(data) / self.ave_num
+                ave_data_li.append(d)
+            return ave_data_li

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -1,4 +1,4 @@
-from typing import List
+# from typing import List
 
 import astropy.units as u
 import pyinterface
@@ -34,7 +34,7 @@ class CPZ3177(BiasReader):
         )
         self.ad.start_sampling("ASYNC")
 
-    def get_data(self, ch) -> List[float]:
+    def get_data(self, ch) -> float:
         with busy(self, "busy"):
             offset = self.ad.get_status()["smpl_count"] - self.ave_num
             data = self.ad.read_sampling_buffer(self.ave_num, offset)

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -1,4 +1,4 @@
-# from typing import List
+from typing import List
 
 import astropy.units as u
 import pyinterface
@@ -34,7 +34,7 @@ class CPZ3177(BiasReader):
         )
         self.ad.start_sampling("ASYNC")
 
-    def get_data(self, ch) -> float:
+    def get_data(self, ch) -> List[float]:
         with busy(self, "busy"):
             offset = self.ad.get_status()["smpl_count"] - self.ave_num
             data = self.ad.read_sampling_buffer(self.ave_num, offset)

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -51,16 +51,16 @@ class CPZ3177(BiasReader):
                 ave_data_li.append(d)
             return ave_data_li[ch]
 
-    def get_bias_voltage(self, ch) -> u.Quantity:  # odd number pci_ch is voltage (x10).
+    def get_bias_voltage(self, ch) -> u.Quantity:
         pci_ch = 2 * ch - 1
         return self.get_data(pci_ch) * 10 * u.mV
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.
+    # odd number pci_ch is voltage (100 mV/mV).
 
-    def get_bias_current(
-        self, ch
-    ) -> u.Quantity:  # even number pci_ch is current (x1000).
+    def get_bias_current(self, ch) -> u.Quantity:
         pci_ch = 2 * ch
         return self.get_data(pci_ch) * 1000 * u.microampere
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.
+    # even number pci_ch is current (1 microA/mV).

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -66,4 +66,4 @@ class CPZ3177(BiasReader):
     # even number pci_ch is current (1 microA/mV).
 
     def finalize(self) -> None:
-        pass
+        self.ad.stop_sampling()

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -64,3 +64,6 @@ class CPZ3177(BiasReader):
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.
     # even number pci_ch is current (1 microA/mV).
+
+    def finalize(self) -> None:
+        pass

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -44,7 +44,11 @@ class CPZ3177(BiasReader):
                 data_li_2.append(data_li)
 
             ave_data_li = []
-            for data in data_li_2:
-                d = sum(data) / self.ave_num
-                ave_data_li.append(d)
-            return ave_data_li
+            for (
+                data
+            ) in (
+                data_li_2
+            ):  # run "for" in range of the length of data_li_2(=all_ch_num?) Is "data" a list?
+                d = sum(data) / self.ave_num  # Cal average
+                ave_data_li.append(d)  # Add average to returned list
+            return ave_data_li  # what value is this in the list? voltage? current?

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -1,9 +1,9 @@
-import pyinterface
-import astropy.units as u
 from typing import List
 
-from ...devices import utils
+import astropy.units as u
+import pyinterface
 
+from ...utils import busy
 from .bias_reader_base import BiasReader
 
 
@@ -35,7 +35,7 @@ class CPZ3177(BiasReader):
         self.ad.start_sampling("ASYNC")
 
     def get_data(self, ch) -> List[float]:
-        with utils.busy(self, "busy"):
+        with busy(self, "busy"):
             offset = self.ad.get_status()["smpl_count"] - self.ave_num
             data = self.ad.read_sampling_buffer(self.ave_num, offset)
             data_li_2 = []

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -76,8 +76,7 @@ bias_reader_ave_num = 100
 bias_reader_smpl_freq = 100
 bias_reader_single_diff = "SINGLE"
 bias_reader_all_ch_num = 8
-bias_reader_smpl_ch_req =
-[
+bias_reader_smpl_ch_req =[
     {ch_no = 1, range = '10V'},
     {ch_no = 2, range = '10V'},
     {ch_no = 3, range = '10V'},

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -72,11 +72,21 @@ thermometer_port = 12
 weather_station_port = "/dev/ttyUSB2"
 
 bias_reader_rsw_id = "0"
-bias_reader_ave_num = 10
-bias_reader_smpl_freq = 1.0
+bias_reader_ave_num = 100
+bias_reader_smpl_freq = 100
 bias_reader_single_diff = "SINGLE"
 bias_reader_all_ch_num = 8
-bias_reader_smpl_ch_req = [1, 2, 3, 4, 5, 6, 7, 8]
+bias_reader_smpl_ch_req =
+[
+    {ch_no = 1, range = '10V'},
+    {ch_no = 2, range = '10V'},
+    {ch_no = 3, range = '10V'},
+    {ch_no = 4, range = '10V'},
+    {ch_no = 5, range = '10V'},
+    {ch_no = 6, range = '10V'},
+    {ch_no = 7, range = '10V'},
+    {ch_no = 8, range = '10V'},
+]
 
 DEV_antenna_motor = "CPZ7415V"
 DEV_chopper_motor = "CPZ7415V"

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -74,17 +74,17 @@ weather_station_port = "/dev/ttyUSB2"
 bias_reader_rsw_id = "0"
 bias_reader_ave_num = 100
 bias_reader_smpl_freq = 100
-bias_reader_single_diff = "SINGLE"
+bias_reader_single_diff = "DIFF"
 bias_reader_all_ch_num = 8
 bias_reader_smpl_ch_req =[
-    {ch_no = 1, range = '10V'},
-    {ch_no = 2, range = '10V'},
-    {ch_no = 3, range = '10V'},
-    {ch_no = 4, range = '10V'},
-    {ch_no = 5, range = '10V'},
-    {ch_no = 6, range = '10V'},
-    {ch_no = 7, range = '10V'},
-    {ch_no = 8, range = '10V'},
+    {ch_no = 1, range = '5V'},
+    {ch_no = 2, range = '5V'},
+    {ch_no = 3, range = '5V'},
+    {ch_no = 4, range = '5V'},
+    {ch_no = 5, range = '5V'},
+    {ch_no = 6, range = '5V'},
+    {ch_no = 7, range = '5V'},
+    {ch_no = 8, range = '5V'},
 ]
 
 DEV_antenna_motor = "CPZ7415V"

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -71,6 +71,13 @@ thermometer_port = 12
 
 weather_station_port = "/dev/ttyUSB2"
 
+bias_reader_rsw_id = "0"
+bias_reader_ave_num = 10
+bias_reader_smpl_freq = 1.0
+bias_reader_single_diff = "SINGLE"
+bias_reader_all_ch_num = 8
+bias_reader_smpl_ch_req = [1, 2, 3, 4, 5, 6, 7, 8]
+
 DEV_antenna_motor = "CPZ7415V"
 DEV_chopper_motor = "CPZ7415V"
 DEV_antenna_encoder = "ND287"

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -35,7 +35,13 @@ rx_fsw0020_host = "192.168.101.120"
 rx_fsw0020_port = 10001
 rx_model218_host = "192.168.100.106"
 rx_model218_gpibaddr = 12
+
 rx_cpz3177_rsw_id = "0"
+rx_cpz3177_ave_num = 10
+rx_cpz3177_smpl_freq = 1.0
+rx_cpz3177_single_diff = "SINGLE"
+rx_cpz3177_all_ch_num = 8
+rx_cpz3177_smpl_ch_req = [1, 2, 3, 4, 5, 6, 7, 8]
 
 chopper_motor_rsw_id = 0
 

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -35,6 +35,7 @@ rx_fsw0020_host = "192.168.101.120"
 rx_fsw0020_port = 10001
 rx_model218_host = "192.168.100.106"
 rx_model218_gpibaddr = 12
+rx_cpz3177_rsw_id = "0"
 
 chopper_motor_rsw_id = 0
 
@@ -78,6 +79,7 @@ DEV_antenna_encoder = "ND287"
 DEV_weather_station = "TR73U"
 DEV_thermometer = "Model218"
 DEV_signal_generator = "FSW0020"
+DEV_bias_reader =  "CPZ3177"
 
 ros_service_timeout_sec = 10
 ros_communication_deadline_sec = 0.01


### PR DESCRIPTION
Adding class reading bias voltage and current. Please check it.

Nb.
以下の/scr/config.toml内のパラメーターはどのように決めるか考えあぐねたため、適当に割り振ってあります。
 - bias_reader_ave_num = 10
 - bias_reader_all_ch_num = 8
 - bias_reader_smpl_ch_req = [1, 2, 3, 4, 5, 6, 7, 8]

残りのパラメータは初めから決まっているものかもしくは`pyinterface`内でデフォルトとして入れてあったものを採用しています。