### PR TITLE
#285 Change gpib communication->usb communication

### DIFF
--- a/neclib/devices/thermometer/model_218.py
+++ b/neclib/devices/thermometer/model_218.py
@@ -12,8 +12,7 @@ class Model218(Thermometer):
     Identifier = "host"
 
     def __init__(self) -> None:
-        com = ogameasure.gpib_prologix(host=self.Config.host, gpibport=self.Config.port)
-        self.thermometer = ogameasure.Lakeshore.model218(com)
+        self.thermometer = ogameasure.Lakeshore.model218_usb(self.Config.usb_port)
 
     def get_temp(self) -> u.Quantity:
         data = self.thermometer.kelvin_reading_query()

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -71,8 +71,7 @@ antenna_encoder_port_el = "/dev/ttyUSB1"
 signal_generator_host = "192.168.101.120"
 signal_generator_port = 10001
 
-thermometer_host = "192.168.100.106"
-thermometer_port = 12
+thermometer_usb_port = "/dev/ttyUSB0"
 
 weather_station_port = "/dev/ttyUSB2"
 

--- a/tests/devices/thermometer/test_model_218.py
+++ b/tests/devices/thermometer/test_model_218.py
@@ -12,4 +12,4 @@ pytestmark = pytest.mark.skipif(
 class TestModel218:
     def test_config_type(self):
         thermometer = get_instance(Model218)
-        assert type(thermometer.Config.usb_port) is int
+        assert type(thermometer.Config.usb_port) is str

--- a/tests/devices/thermometer/test_model_218.py
+++ b/tests/devices/thermometer/test_model_218.py
@@ -12,5 +12,4 @@ pytestmark = pytest.mark.skipif(
 class TestModel218:
     def test_config_type(self):
         thermometer = get_instance(Model218)
-        assert type(thermometer.Config.host) is str
-        assert type(thermometer.Config.port) is int
+        assert type(thermometer.Config.usb_port) is int


### PR DESCRIPTION
Change communication method, GPIB to USB

1.85m 望遠鏡がUSB接続での値読み取りに対応していたので修正しました。
`ogameasure` 内の`model218_sub.py` を利用しています。