### PR TITLE
#288 bias parameter

### DIFF
--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -21,6 +21,7 @@ class CPZ3177(BiasReader):
         self.single_diff = self.Config.single_diff
         self.all_ch_num = self.Config.all_ch_num
         self.smpl_ch_req = self.Config.smpl_ch_req
+        self.ch_selector = self.Config.ch_selector
 
         self.ad = pyinterface.open(3177, self.rsw_id)
         self.ad.stop_sampling()
@@ -52,14 +53,14 @@ class CPZ3177(BiasReader):
             return ave_data_li[ch - 1]
 
     def get_bias_voltage(self, ch) -> u.Quantity:
-        pci_ch = self.Config.ch_selector["bias_ch{}_v".format(ch)]
+        pci_ch = self.ch_selector["bias_ch{}_v".format(ch)]
         return self.get_data(pci_ch) * 10 * u.mV
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.
     # odd number pci_ch is voltage (100 mV/mV).
 
     def get_bias_current(self, ch) -> u.Quantity:
-        pci_ch = self.Config.ch_selector["bias_ch{}_i".format(ch)]
+        pci_ch = self.ch_selector["bias_ch{}_i".format(ch)]
         return self.get_data(pci_ch) * 1000 * u.microampere
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -22,6 +22,8 @@ class CPZ3177(BiasReader):
         self.all_ch_num = self.Config.all_ch_num
         self.smpl_ch_req = self.Config.smpl_ch_req
         self.ch_selector = self.Config.ch_selector
+        self.v_mag = self.Config.v_mag
+        self.i_mag = self.Config.i_mag
 
         self.ad = pyinterface.open(3177, self.rsw_id)
         self.ad.stop_sampling()
@@ -53,18 +55,18 @@ class CPZ3177(BiasReader):
             return ave_data_li[ch - 1]
 
     def get_bias_voltage(self, ch) -> u.Quantity:
-        pci_ch = self.ch_selector["bias_ch{}_v".format(ch)]
-        return self.get_data(pci_ch) * 10 * u.mV
+        ch_name = "bias_ch{}_v".format(ch)
+        pci_ch = self.ch_selector[ch_name]
+        return self.get_data(pci_ch) * self.v_mag * u.mV
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.
-    # odd number pci_ch is voltage (100 mV/mV).
 
     def get_bias_current(self, ch) -> u.Quantity:
-        pci_ch = self.ch_selector["bias_ch{}_i".format(ch)]
-        return self.get_data(pci_ch) * 1000 * u.microampere
+        ch_name = "bias_ch{}_i".format(ch)
+        pci_ch = self.ch_selector[ch_name]
+        return self.get_data(pci_ch) * self.i_mag * u.microampere
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.
-    # even number pci_ch is current (1 microA/mV).
 
     def finalize(self) -> None:
         self.ad.stop_sampling()

--- a/neclib/devices/bias_reader/cpz3177.py
+++ b/neclib/devices/bias_reader/cpz3177.py
@@ -52,14 +52,14 @@ class CPZ3177(BiasReader):
             return ave_data_li[ch - 1]
 
     def get_bias_voltage(self, ch) -> u.Quantity:
-        pci_ch = 2 * ch - 1
+        pci_ch = self.Config.ch_selector["bias_ch{}_v".format(ch)]
         return self.get_data(pci_ch) * 10 * u.mV
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.
     # odd number pci_ch is voltage (100 mV/mV).
 
     def get_bias_current(self, ch) -> u.Quantity:
-        pci_ch = 2 * ch
+        pci_ch = self.Config.ch_selector["bias_ch{}_i".format(ch)]
         return self.get_data(pci_ch) * 1000 * u.microampere
 
     # This "ch" which is argument of this function is ch of bias box, not pci board.

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -81,19 +81,24 @@ bias_reader_rsw_id = "0"
 bias_reader_ave_num = 100
 bias_reader_smpl_freq = 100
 bias_reader_single_diff = "DIFF"
-bias_reader_all_ch_num = 4
+bias_reader_all_ch_num = 12
 bias_reader_smpl_ch_req =[
     {ch_no = 1, range = '5V'},
     {ch_no = 2, range = '5V'},
     {ch_no = 3, range = '5V'},
     {ch_no = 4, range = '5V'},
+    {ch_no = 5, range = '5V'},
+    {ch_no = 6, range = '5V'},
+    {ch_no = 7, range = '5V'},
+    {ch_no = 8, range = '5V'},
+    {ch_no = 9, range = '5V'},
+    {ch_no = 10, range = '5V'},
+    {ch_no = 11, range = '5V'},
+    {ch_no = 12, range = '5V'},
 ]
-bias_reader_ch_selector = {
-    "bias_ch1_v":1,
-    "bias_ch1_i":2,
-    "bias_ch2_v":3,
-    "bias_ch2_i":4
-}
+bias_reader_ch_selector = {bias_ch1_v = 7, bias_ch1_i = 8, bias_ch2_v = 5, bias_ch2_i = 6}
+bias_reader_v_mag = 5
+bias_reader_i_mag = 500
 
 DEV_antenna_motor = "CPZ7415V"
 DEV_chopper_motor = "CPZ7415V"

--- a/neclib/src/config.toml
+++ b/neclib/src/config.toml
@@ -81,17 +81,19 @@ bias_reader_rsw_id = "0"
 bias_reader_ave_num = 100
 bias_reader_smpl_freq = 100
 bias_reader_single_diff = "DIFF"
-bias_reader_all_ch_num = 8
+bias_reader_all_ch_num = 4
 bias_reader_smpl_ch_req =[
     {ch_no = 1, range = '5V'},
     {ch_no = 2, range = '5V'},
     {ch_no = 3, range = '5V'},
     {ch_no = 4, range = '5V'},
-    {ch_no = 5, range = '5V'},
-    {ch_no = 6, range = '5V'},
-    {ch_no = 7, range = '5V'},
-    {ch_no = 8, range = '5V'},
 ]
+bias_reader_ch_selector = {
+    "bias_ch1_v":1,
+    "bias_ch1_i":2,
+    "bias_ch2_v":3,
+    "bias_ch2_i":4
+}
 
 DEV_antenna_motor = "CPZ7415V"
 DEV_chopper_motor = "CPZ7415V"


### PR DESCRIPTION
Updating some parameter for OPU1.85m.

## 詳細
 - 想定していた配線と違う配線でバイアスボックス周りが組まれていたので任意の配線に対応できるように修正しました。
 - 利用するチャンネル番号よりも多くの設定を`smpl_ch_req`で行う必要があります。
   - 例えば、読み出しチャンネルとして`ch = 5, 6, 8, 10, 12`を利用するのであれば最低限ch12まで設定する必要があります。
   - これを応用するとchごとに差動入力とシングルエンド入力を切り替えることができるかと思います。
     - ただしこれを利用する際には物理的に配線が重複しないようにデザインする必要があり注意が必要です。
 - `all_ch_num`は`smpl_ch_req`と同数のチャンネル数を入力する必要があります。
   - 逆に`all_ch_num`と同じだけ`smpl_ch_req`を書き込む必要があります。
   - 最大値は差動入力で32、シングルエンド入力では64です。
 - `ch_selector`では各チャンネルがバイアスボックスのどのCHに対応しているかを書き込みます。
   - ただし必ずしも`all_ch_num`の数だけ設定する必要はなく最低限読み出す予定のチャンネルのみを設定すれば良いです。
 - `v_mag`と`i_mag`では読み出しの実際の値に対して掛けることでSIS素子にかかっているバイアス電圧・電流を計算するためのFoctorを設定します。
   - この値はバイアスボックスの可変抵抗の値で決定します。OPU1.85mの場合は電圧が5倍、電流は500倍です。

### 補足
 - 今回のPull Requestで設定されている`bias_reader_ch_selector`の値は実際にOPU1.85mに実装されている値です。
 - なお、テスターの値と読み取りの値を比較したときに若干値に齟齬があることがわかっているので現段階ではDraftとします。